### PR TITLE
fix-sp

### DIFF
--- a/uclliu.pyw
+++ b/uclliu.pyw
@@ -974,12 +974,15 @@ uclcode_r = {}
 #only short key
 for k in uclcode["chardefs"]:
    for kk in range(0,len(uclcode["chardefs"][k])):
-     _word = uclcode["chardefs"][k][kk]     
+     _word = uclcode["chardefs"][k][kk]
+     temp_k = k
+     if kk>0:
+       temp_k = unicode(str(k)+str(kk))
      if _word not in uclcode_r:
-       uclcode_r[_word] = k
+       uclcode_r[_word] = temp_k
      else:
-       if len(k) < len(uclcode_r[_word]):
-         uclcode_r[_word] = k
+       if len(temp_k) < len(uclcode_r[_word]):
+         uclcode_r[_word] = temp_k
 
 
 def thread___playMusic(keyboard_volume):


### PR DESCRIPTION
修正簡根出現文字
ex: 舅應為GDV而非GQD(實際上是GQD1)
做法就是在第一個以外的後面加數字，
GQD共有三個字 動 舅 娚分別變成:
動=>GQD 舅=>GQD1 娚=>GQD2
看了一下Code 目前應該沒有 V R S怎麼做的想法