### PR TITLE
字表裡面沒有字 一樣會出字

### DIFF
--- a/uclliu.pyw
+++ b/uclliu.pyw
@@ -2916,7 +2916,7 @@ def OnKeyboardEvent(event):
             if _s[i] in LAST_CODE:
               _is_sound_kick = True 
          
-        if is_need_use_phone == False and len(ucl_find_data)>=1 and int(chr(event.Ascii)) < len(ucl_find_data):
+        if is_need_use_phone == False and len(ucl_find_data)>=1 and int(chr(event.Ascii)) < len(ucl_find_data) and len(word_label.get_text())>0:
           # send data        
           data = ucl_find_data[int(chr(event.Ascii))]
           #debug_print(ucl_find_data)


### PR DESCRIPTION
我習慣都用space出字，忘了也可以透過數字出字
ex h backspace 1
應該要出現1而不是时
為了改這個然後發現另一個bug XD
用h1的時候會跳出  hv 或 h1，但hv 是惟是打不出时的
等等開個issue