### PR TITLE
fix short mode display

### DIFF
--- a/uclliu.pyw
+++ b/uclliu.pyw
@@ -595,9 +595,9 @@ def run_short():
   type_label.set_visible(False)
   gamemode_btn.set_visible(False)
   config["DEFAULT"]["SHORT_MODE"]="1"
-  
-  
   saveConfig()
+  tray.reload_tray()
+  
 def run_long():
   global config
   global word_label
@@ -620,6 +620,7 @@ def run_long():
   
   config["DEFAULT"]["SHORT_MODE"]="0"
   saveConfig()
+  tray.reload_tray()
 
 saveConfig()    
 #check if exists tab cin json


### PR DESCRIPTION
透過,,,l   ,,,s 調整mode時
與gui 呈現不一致   如下圖
![short_mode](https://github.com/user-attachments/assets/d846941b-d7d7-4839-8d41-b9f88535519d)

若不調整若前一次是用,,,l or ,,,s   則gui 要點兩次才會作動
